### PR TITLE
Fix Systemd build on Bananpi, Assuming same on Cubieboard2/Cubietruck

### DIFF
--- a/projects/Bananapi/patches/systemd/systemd-20-fix-sunxi-build.patch
+++ b/projects/Bananapi/patches/systemd/systemd-20-fix-sunxi-build.patch
@@ -7,20 +7,6 @@ Now we are getting into kernel < 3.4 territory...
 
 https://bugs.freedesktop.org/show_bug.cgi?id=80095
 ---
-diff --git a/configure.ac b/configure.ac
-index 94aacc9..be05211 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -310,7 +310,8 @@ AC_CHECK_DECLS([gettid, pivot_root, name_to_handle_at, setns, LO_FLAGS_PARTSCAN]
- #include <linux/loop.h>
- ]])
- 
--AC_CHECK_DECLS([IFLA_PHYS_PORT_ID,
-+AC_CHECK_DECLS([IFLA_MACVLAN_FLAGS,
-+                IFLA_PHYS_PORT_ID,
-                 IFLA_BOND_AD_INFO,
-                 IFLA_VLAN_PROTOCOL,
-                 IFLA_VXLAN_LOCAL6,
 diff --git a/src/shared/missing.h b/src/shared/missing.h
 index f129f0b..818d704 100644
 --- a/src/shared/missing.h

--- a/projects/Bananapi/patches/systemd/systemd-22-fix-sunxi-build.patch
+++ b/projects/Bananapi/patches/systemd/systemd-22-fix-sunxi-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/shared/missing.h b/src/shared/missing.h index 3ff1a21..1321db1 100644 
+--- a/src/shared/missing.h 
++++ b/src/shared/missing.h 
+@@ -611,3 +611,7 @@ static inline int setns(int fd, int nstype) {
+ #ifndef NET_NAME_RENAMED
+ #  define NET_NAME_RENAMED 4 
+ #endif
++ 
++#ifndef BPF_XOR 
++# define BPF_XOR 0xa0 
++#endif 
+--
+2.1.0.rc1

--- a/projects/Cubieboard2/patches/systemd/systemd-20-fix-sunxi-build.patch
+++ b/projects/Cubieboard2/patches/systemd/systemd-20-fix-sunxi-build.patch
@@ -7,20 +7,6 @@ Now we are getting into kernel < 3.4 territory...
 
 https://bugs.freedesktop.org/show_bug.cgi?id=80095
 ---
-diff --git a/configure.ac b/configure.ac
-index 94aacc9..be05211 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -310,7 +310,8 @@ AC_CHECK_DECLS([gettid, pivot_root, name_to_handle_at, setns, LO_FLAGS_PARTSCAN]
- #include <linux/loop.h>
- ]])
- 
--AC_CHECK_DECLS([IFLA_PHYS_PORT_ID,
-+AC_CHECK_DECLS([IFLA_MACVLAN_FLAGS,
-+                IFLA_PHYS_PORT_ID,
-                 IFLA_BOND_AD_INFO,
-                 IFLA_VLAN_PROTOCOL,
-                 IFLA_VXLAN_LOCAL6,
 diff --git a/src/shared/missing.h b/src/shared/missing.h
 index f129f0b..818d704 100644
 --- a/src/shared/missing.h

--- a/projects/Cubieboard2/patches/systemd/systemd-22-fix-sunxi-build.patch
+++ b/projects/Cubieboard2/patches/systemd/systemd-22-fix-sunxi-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/shared/missing.h b/src/shared/missing.h index 3ff1a21..1321db1 100644 
+--- a/src/shared/missing.h 
++++ b/src/shared/missing.h 
+@@ -611,3 +611,7 @@ static inline int setns(int fd, int nstype) {
+ #ifndef NET_NAME_RENAMED
+ #  define NET_NAME_RENAMED 4 
+ #endif
++ 
++#ifndef BPF_XOR 
++# define BPF_XOR 0xa0 
++#endif 
+--
+2.1.0.rc1

--- a/projects/Cubietruck/patches/systemd/systemd-20-fix-sunxi-build.patch
+++ b/projects/Cubietruck/patches/systemd/systemd-20-fix-sunxi-build.patch
@@ -7,20 +7,6 @@ Now we are getting into kernel < 3.4 territory...
 
 https://bugs.freedesktop.org/show_bug.cgi?id=80095
 ---
-diff --git a/configure.ac b/configure.ac
-index 94aacc9..be05211 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -310,7 +310,8 @@ AC_CHECK_DECLS([gettid, pivot_root, name_to_handle_at, setns, LO_FLAGS_PARTSCAN]
- #include <linux/loop.h>
- ]])
- 
--AC_CHECK_DECLS([IFLA_PHYS_PORT_ID,
-+AC_CHECK_DECLS([IFLA_MACVLAN_FLAGS,
-+                IFLA_PHYS_PORT_ID,
-                 IFLA_BOND_AD_INFO,
-                 IFLA_VLAN_PROTOCOL,
-                 IFLA_VXLAN_LOCAL6,
 diff --git a/src/shared/missing.h b/src/shared/missing.h
 index f129f0b..818d704 100644
 --- a/src/shared/missing.h

--- a/projects/Cubietruck/patches/systemd/systemd-22-fix-sunxi-build.patch
+++ b/projects/Cubietruck/patches/systemd/systemd-22-fix-sunxi-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/shared/missing.h b/src/shared/missing.h index 3ff1a21..1321db1 100644 
+--- a/src/shared/missing.h 
++++ b/src/shared/missing.h 
+@@ -611,3 +611,7 @@ static inline int setns(int fd, int nstype) {
+ #ifndef NET_NAME_RENAMED
+ #  define NET_NAME_RENAMED 4 
+ #endif
++ 
++#ifndef BPF_XOR 
++# define BPF_XOR 0xa0 
++#endif 
+--
+2.1.0.rc1


### PR DESCRIPTION
Deleted 1º patch at systemd/systemd-20-fix-sunxi-build.patch

Added new patch fixing missing BPF_XOR definition.
