### PR TITLE
Update network-online.service

### DIFF
--- a/packages/network/connman/system.d/network-online.service
+++ b/packages/network/connman/system.d/network-online.service
@@ -5,7 +5,6 @@ After=connman.service
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/sh -c 'echo "waiting on Network to come online ..."'
 ExecStart=/usr/bin/cm-online 30
 StandardOutput=tty
 


### PR DESCRIPTION
Prevent the network-online.service from printing a message to the TTY by removing the ExecStartPre line from the network-online.service config file.  This message is not helpful and is visible when loading or reloading the Lakka menu.