### PR TITLE
Set OPTIMIZATIONS="normal" for generic x64.

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -57,7 +57,7 @@
 ################################################################################
 
   # Build optimizations (size/normal)
-    OPTIMIZATIONS="size"
+    OPTIMIZATIONS="normal"
 
   # Project CFLAGS
     PROJECT_CFLAGS="-mmmx -msse -msse2 -mfpmath=sse"


### PR DESCRIPTION
- Before it was set to optimize for size,
  but for an x64 build we shouldn't be size constrained
  and just want the fastest performance.
- This will result in -02 instead of -0s.
