### PR TITLE
Apply Brunnis input lag fix to bsnes mercury

### DIFF
--- a/packages/libretro/bsnes-mercury/patches/bsnes-mercury-0001-Apply-Brunnis-input-lag-fix.patch
+++ b/packages/libretro/bsnes-mercury/patches/bsnes-mercury-0001-Apply-Brunnis-input-lag-fix.patch
@@ -1,0 +1,30 @@
+From f88e8d47bec8315dc3b0a15f73270360c55314ba Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lars=20Kj=C3=A6rgaard?= <larskj@gmail.com>
+Date: Sun, 26 Jun 2016 16:21:18 +0200
+Subject: [PATCH] Apply Brunnis input lag fix.
+
+---
+ sfc/system/system.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/sfc/system/system.cpp b/sfc/system/system.cpp
+index 4d5db29..27ea216 100644
+--- a/sfc/system/system.cpp
++++ b/sfc/system/system.cpp
+@@ -282,7 +282,12 @@ void System::reset() {
+ 
+ void System::scanline() {
+   video.scanline();
+-  if(cpu.vcounter() == 241) scheduler.exit(Scheduler::ExitReason::FrameEvent);
++
++  const int vcounter_time_to_exit = ( ppu.overscan() == false ? 225 : 240 );
++
++  // Exit exactly at the right moment in order to minimize input latency - this cuts off 1 full frame of delay.
++  if( cpu.vcounter() == vcounter_time_to_exit )
++    scheduler.exit( Scheduler::ExitReason::FrameEvent );
+ }
+ 
+ void System::frame() {
+-- 
+2.7.4
+


### PR DESCRIPTION
This applies Brunnis' input lag fix to the bsnes-mercury core from:

http://libretro.com/forums/showthread.php?t=5428&page=15

He figured out that by exiting bsnes at the right moment you can remove one full frame of delay.

A pull request has also been made at github for bsnes-mercury:

https://github.com/libretro/bsnes-mercury/pull/17

But in case you want it before or it is never merged to mainline, you can grab it here instead.
