### PR TITLE
Add snd-hda-intel modprobe configuration

### DIFF
--- a/packages/audio/alsa-lib/config/modprobe.d/snd-hda-intel.conf
+++ b/packages/audio/alsa-lib/config/modprobe.d/snd-hda-intel.conf
@@ -1,0 +1,3 @@
+# Prevent abnormal drivers from grabbing index 0
+options snd-hda-intel index=-2
+


### PR DESCRIPTION
This configuration will prevent issue for Intel High Definition Audio

`ALSA lib /home/kivutar/Lakka/build.Lakka-Generic.x86_64-devel/alsa-lib-1.1.0/src/pcm/pcm_dmix.c:1029:(snd_pcm_dmix_open)`
