### PR TITLE
Add --disable-bindings to llvm configure.

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -50,7 +50,8 @@ PKG_CONFIGURE_OPTS_HOST="--disable-polly \
                          --disable-debug-runtime \
                          --disable-debug-symbols \
                          --enable-keep-symbols \
-                         --enable-targets=r600"
+                         --enable-targets=r600 \
+                         --disable-bindings"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-polly \
                            --disable-libcpp \
@@ -80,7 +81,8 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-polly \
                            --enable-timestamps \
                            --disable-backtraces \
                            --disable-libffi \
-                           --disable-ltdl-install"
+                           --disable-ltdl-install \
+                           --disable-bindings"
 
 if [ "$TARGET_ARCH" = i386 ]; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-targets=x86,r600"


### PR DESCRIPTION
This fixes building for me on Ubuntu 14.04. Otherwise, llvm can't find
ocaml ctypes in order to build llvm with ocaml bindings.

The ocaml-ctypes package isn't available in Ubuntu 14.04. So, it's easier
to just leave it out because it doesn't seem like Lakka needs ocaml
bindings for llvm for anything else. This might have broken with the move to [llvm 3.6](http://llvm.org/releases/3.6.1/docs/ReleaseNotes.html#changes-to-the-ocaml-bindings).

Tested on Ubuntu 14.04 and a full successful build with "make image." I still haven't tested the actual image, though. Looks like other distros do something similar (e.g., [fedora](https://lists.fedoraproject.org/pipermail/devel/2015-March/208677.html))
