### PR TITLE
Bump binutils to 2.26.1.

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="binutils"
-PKG_VERSION="2.25"
+PKG_VERSION="2.26.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Fixes "unsupported reloc 42 againts global symbol..."
Newer binutils support new relocation types.
Needed to properly build lakka with a host gcc5 and host gcc6 (or
even a host gcc4 built with a newer gcc ;)). "We must go deeper."
