### PR TITLE
Update odroid xu3/4 boot.ini

### DIFF
--- a/projects/OdroidXU3/bootloader/boot.ini
+++ b/projects/OdroidXU3/bootloader/boot.ini
@@ -68,7 +68,7 @@ setenv bootcmd "${kernel}; ${initrd}; ${dtb}; bootz 40008000 - 44000000"
 # Kernel boot
 #
 #------------------------------------------------------------------------------------------------------
-setenv bootargs "${console} ${bootrootfs} ${openelec} smsc95xx.macaddr=${macaddr}"
+setenv bootargs "${console} ${bootrootfs} ${video_output} ${openelec} smsc95xx.macaddr=${macaddr}"
 
 # Boot the board
 boot


### PR DESCRIPTION
added arg which was missing to allow for setting the video mode at boot.

man github makes it really easy to do this.
