### PR TITLE
Update 99-fix-controller.rules

### DIFF
--- a/packages/linux/udev.d/99-fix-controller.rules
+++ b/packages/linux/udev.d/99-fix-controller.rules
@@ -6,3 +6,5 @@
 
 SUBSYSTEM=="input", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7210", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_MOUSE}=""
 
+# Same goes for the OUYA controller
+SUBSYSTEM=="input", ATTRS{name}=="OUYA Game Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_MOUSE}=""


### PR DESCRIPTION
The OUYA controller has a mouse component causing it to not appear as a controller.

Note: I have tested this rule in its own file, but not when combined into this same file.
The name of this file would indicate it is intended to be used to fix multiple controllers, so I added it here.
