### PR TITLE
Fix snes9x patch fail problem

### DIFF
--- a/packages/libretro/snes9x/patches/snes9x-01-buildfix.patch
+++ b/packages/libretro/snes9x/patches/snes9x-01-buildfix.patch
@@ -5,8 +5,8 @@ diff -Naur snes9x.git/libretro/Makefile snes9x.patch/libretro/Makefile
  	endif
  endif
  
--CXX			= g++
--CC			= gcc
+-CXX			?= g++
+-CC			?= gcc
  TARGET_NAME	= snes9x
  LIBM		= -lm
  


### PR DESCRIPTION
This fixes the patch file to include the missing "?" symbol from the compiler flags entries. This allows Lakka to build correctly.