### PR TITLE
retroarch: add udev rule to force detection of ION iCade devices

### DIFF
--- a/packages/libretro/retroarch/udev.d/99-ION-iCade-bluetooth.rules
+++ b/packages/libretro/retroarch/udev.d/99-ION-iCade-bluetooth.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="input", ATTRS{name}=="ION iCade", KERNEL=="event*", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
Defined in kernel as:

USB_VENDOR_ID_ION               0x15e4
USB_DEVICE_ID_ICADE             0x0132

These devices only expose
E: ID_INPUT=1
E: ID_INPUT_KEY=1

but the test on the event* is done for ID_INPUT_JOYSTICK.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>