### PR TITLE
add 'assets' smb share

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -61,6 +61,14 @@
 # Using the following configurations as a template allows you to add
 # writable shares of disks and paths under /storage
 
+[assets]
+  path = /storage/.assets
+  available = yes
+  browsable = yes
+  public = yes
+  writable = yes
+  root preexec = mkdir -p /storage/.assets
+  
 [Update]
   path = /storage/.update
   available = yes

--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -61,7 +61,7 @@
 # Using the following configurations as a template allows you to add
 # writable shares of disks and paths under /storage
 
-[assets]
+[Assets]
   path = /storage/.assets
   available = yes
   browsable = yes


### PR DESCRIPTION
This PR exposes /storage/assets as a Samba share.

The intention is to make it one step easier to copy custom theme artwork to Lakka, even though the user will still have to change the assets folder in the RetroArch settings per https://github.com/libretro/Lakka/wiki/Playlists#icons